### PR TITLE
Fixed #181 unexpected behavior of diff viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - The "Hide AC" button is removed. (But a similiar action is added in the "More" menu of testcases.)
 
 ### Fix
-- The diff viewer shows line-breaks now.
+- Show line-breaks without "¶" in the Diff Viewer when "Display new-line characters in the Diff Viewer" option is not checked. (#181)
 
 ## v6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 - The "Hide AC" button is removed. (But a similiar action is added in the "More" menu of testcases.)
 
+### Fix
+- The diff viewer shows line-breaks now.
+
 ## v6.0
 
 It's the first version after the versioning rules changed, so there's no change log before v6.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - The "Hide AC" button is removed. (But a similiar action is added in the "More" menu of testcases.)
 
-### Fix
+### Fixed
 - Show line-breaks without "¶" in the Diff Viewer when "Display new-line characters in the Diff Viewer" option is not checked. (#181)
 
 ## v6.0

--- a/src/Widgets/TestCases.cpp
+++ b/src/Widgets/TestCases.cpp
@@ -403,6 +403,8 @@ void TestCase::on_diffButton_clicked()
             QString text = diff.text.toHtmlEscaped().replace(" ", "&nbsp;");
             if (Settings::SettingsManager::isDisplayEolnInDiff())
                 text.replace("\n", "&para;<br>");
+            else
+                text.replace("\n", "<br>");
             switch (diff.operation)
             {
             case INSERT:


### PR DESCRIPTION
The diff viewer was not showing line breaks.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Tested on which OS(s)? Tested on light/dark system theme? -->

## Screenshots (if appropriate)

## Type of changes
<!--- What type of changes does your code introduce? Put an `x` in the box that applies: -->
- [x] Bug fix (changes which fix an issue)
- [ ] New feature (changes which add functionality)
- [ ] Documentation (changes which modify the documentation only)
- [ ] Style change (changes which do not affect the meaning of the code: code formatting, etc.)
- [ ] Refactor (changes which affect the meaning of the code but neither fix a bug nor add a feature)
- [ ] Performance improve (changes which improve performance)
- [ ] Test (changes which add tests)
- [ ] Build (Changes that affect the build system or external dependencies)
- [ ] CI (changes to CI configuration files and scripts)
- [ ] Chore (changes which do not belong to any type above)
- [ ] Revert (revert previous changes)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/cpeditor/cp-editor/blob/master/CONTRIBUTING.md) document.
- [x] I have tested these changes locally, and this fixes the bug/the new feature behaves as the expectation.
- [x] I have used clang-format-9 and `.clang-format` file in the root directory to format my codes.
- [x] The settings file in the old version can be used in the new version after this change.
- [x] These changes only fix a single bug/introduces a single feature. (Otherwise, open multiple Pull Requests instead, unless these bugs/features are closely related.)
- [x] The commit messages are clear and detailed. (Otherwise, use `git reset` and commit again, or use `git rebase -i` and `git commit --amend` to modify the commit messages.)
- [x] These changes don't remove an existing feature. (Otherwise, add an option to disable this feature instead, unless it's necessary to remove this feature.)
